### PR TITLE
Re-enable force-update for Android apps < 1.2.0

### DIFF
--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/verifier/ws/controller/VerifierConfigController.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/verifier/ws/controller/VerifierConfigController.java
@@ -67,8 +67,7 @@ public class VerifierConfigController {
         configResponse.setWorks(faqHelper.getVerifierFaqWorks());
 
         Version clientAppVersion = new Version(appversion);
-        if (clientAppVersion.isSmallerVersionThan(FORCE_UPDATE_BELOW_1_2_0) && clientAppVersion
-            .isIOS()) {
+        if (clientAppVersion.isSmallerVersionThan(FORCE_UPDATE_BELOW_1_2_0)) {
             configResponse.setForceUpdate(true);
         }
 

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
@@ -85,8 +85,7 @@ public class WalletConfigController {
         configResponse.setPdfGenerationActive(pdfGenerationActive);
 
         Version clientAppVersion = new Version(appversion);
-        if (clientAppVersion.isSmallerVersionThan(FORCE_UPDATE_BELOW_1_2_0)
-                && clientAppVersion.isIOS()) {
+        if (clientAppVersion.isSmallerVersionThan(FORCE_UPDATE_BELOW_1_2_0)) {
             configResponse.setForceUpdate(true);
         }
 


### PR DESCRIPTION
This PR re-enables force-update for Android apps < 1.2.0 as new version should be fully available on Playstore now.