### PR TITLE
Force update wallet-apps below version 2.5.0

### DIFF
--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
@@ -37,8 +37,7 @@ public class WalletConfigController {
     protected final FaqHelper faqHelper;
     private final InfoBoxHelper infoBoxHelper;
 
-    private static final Version INFOBOX_BELOW_2_5_0 = new Version("2.5.0");
-    private static final Version FORCE_UPDATE_BELOW_1_2_0 = new Version("1.2.0");
+    private static final Version FORCE_UPDATE_BELOW_2_5_0 = new Version("2.5.0");
     private static final Version DEACTIVATE_PDF_BELOW_2_2_0 = new Version("2.2.0");
     private static final Version TRANSFER_CODE_VALIDITY_30_DAYS_2_7_0 = new Version("2.7.0");
 
@@ -129,13 +128,8 @@ public class WalletConfigController {
             configResponse.setPdfGenerationActive(pdfGenerationActive);
         }
 
-        if (clientAppVersion.isSmallerVersionThan(FORCE_UPDATE_BELOW_1_2_0)) {
+        if (clientAppVersion.isSmallerVersionThan(FORCE_UPDATE_BELOW_2_5_0)) {
             configResponse.setForceUpdate(true);
-        }
-
-        if (clientAppVersion.isSmallerVersionThan(INFOBOX_BELOW_2_5_0)
-                && !configResponse.isForceUpdate()) {
-            configResponse.setInfoBox(infoBoxHelper.getUpdateInfoBox(clientAppVersion.isAndroid()));
         }
 
         String transferCodeValidity;

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/test/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/BaseControllerTest.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/test/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/BaseControllerTest.java
@@ -191,7 +191,7 @@ public abstract class BaseControllerTest {
                         .getResponse();
         ConfigResponse resp =
                 testHelper.toConfigResponse(result, acceptMediaType, TestHelper.PATH_TO_CA_PEM);
-        ConfigAsserter.assertIsNoForceUpdate(resp);
+        ConfigAsserter.assertIsForceUpdate(resp);
     }
 
     @Test


### PR DESCRIPTION
This pull-request enables the force-update flag for wallet-apps below version 2.5.0, as the validity end of tourist certificates will show the wrong date. Newer versions of the app include an updated version of the SDK, which calculate the validity using displayRules (CertLogic)