### PR TITLE
change replacement pattern for transfer code validity in faq

### DIFF
--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
@@ -148,7 +148,7 @@ de:
     covid_certificate_test_title: Test
     wallet_certificate_test_result_title: Ergebnis
     wallet_certificate_test_result_negativ: Nicht erkannt (Negativ)
-    wallet_certificate_test_result_positiv: Positiv
+    wallet_certificate_test_result_positiv: Erkannt (Positiv)
     wallet_certificate_test_type: Typ
     wallet_certificate_test_name: Name
     wallet_certificate_test_holder: Hersteller
@@ -242,7 +242,7 @@ de:
     wallet_homescreen_network_error: Gültigkeit konnte nicht ermittelt werden
     wallet_transfer_code_faq_works_intro_1: Die App prüft regelmässig, ob ein Covid-Zertifikat für Ihren Transfer-Code verfügbar ist.
     wallet_transfer_code_faq_works_intro_2: Sobald das Covid-Zertifikat verfügbar ist, erscheint es in der App. Wenn Sie Mitteilungen aktiviert haben, werden Sie von der App benachrichtigt.
-    wallet_transfer_code_faq_works_intro_3: Nach <transferCodeValidity> Tagen läuft der Transfer-Code ab. Danach wartet die App noch für weitere 72h auf einen möglichen Transfer, bevor der Transfer-Code ungültig wird.
+    wallet_transfer_code_faq_works_intro_3: Nach {TRANSFER_CODE_VALIDITY} Tagen läuft der Transfer-Code ab. Danach wartet die App noch für weitere 72h auf einen möglichen Transfer, bevor der Transfer-Code ungültig wird.
     wallet_notification_permission_title: Mitteilungen erlauben
     wallet_notification_permission_text: Die App kann Sie informieren, sobald das Zertifikat eingetroffen ist.  Erlauben Sie dazu der App, Ihnen Mitteilungen zu senden.
     wallet_notification_permission_button: Weiter
@@ -444,3 +444,24 @@ de:
     verifier_qr_scanner_external_hardware_detected: Externer Hardwarescanner erkannt
     error_decryption_reset_button: Zurücksetzen
     error_decryption_text: Zertifikate konnten nicht geladen werden\n\nCode: {ERROR_CODE}
+    covid_certificate_sero_positiv_test_title: Genesung (Antikörper)
+    wallet_time_inconsistency_error_title: Prüfung nicht möglich
+    wallet_time_inconsistency_error_text: Datum, Uhrzeit oder Zeitzone auf dem Gerät sind falsch eingestellt.
+    wallet_info_box_certificate_scan_title: Wollen Sie Zertifikate überprüfen?
+    wallet_info_box_certificate_scan_text: Für eine Datenschutzkonforme und schnellere Prüfung nutzen Sie die "COVID Certificate Check"-App.
+    wallet_info_box_certificate_scan_button_check_app: Zur Check-App
+    wallet_info_box_certificate_scan_close: Verstanden
+    wallet_info_box_certificate_scan_text_bold: «COVID Certificate Check»-App.
+    wallet_only_valid_in_switzerland: Nur mit einem Ausweisdokument \n& innerhalb der Schweiz gültig
+    covid_certificate_sero_positiv_test_befund_label: Befund
+    covid_certificate_sero_positiv_test_befund_value: Genügend
+    wallet_certificate_ausnahme_test_attest_start_date: Startdatum des Attests
+    wallet_certificate_ausnahme_responsible_issuer: Verantwortliche Stelle für Ausstellung
+    covid_certificate_ch_ausnahme_test_title: Ausnahme Zertifikat
+    infobox_update_title: Neue Version verfügbar
+    infobox_update_text: Laden Sie die neue Version der App.
+    infobox_update_button: Aktualisieren
+    vaccination_impf_check_info_text: Der Covid-19 Impf-Check gibt Auskunft über Erst- sowie Auffrischimpfungen und führt Sie zur entsprechenden Anlaufstelle in Ihrem Kanton.
+    vaccination_impf_check_action: Zum Impf-Check
+    vaccination_impf_check_url: https://covid19.impf-check.ch/
+    vaccination_impf_check_title: Jetzt Termin buchen

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
@@ -148,7 +148,7 @@ en:
     covid_certificate_test_title: Test
     wallet_certificate_test_result_title: Result
     wallet_certificate_test_result_negativ: Not detected (Negative)
-    wallet_certificate_test_result_positiv: Positive
+    wallet_certificate_test_result_positiv: Detected (Positive)
     wallet_certificate_test_type: Type
     wallet_certificate_test_name: Name
     wallet_certificate_test_holder: Manufacturer
@@ -242,7 +242,7 @@ en:
     wallet_homescreen_network_error: Validity could not be determined
     wallet_transfer_code_faq_works_intro_1: The application regularly checks whether a COVID certificate is available for your transfer code.
     wallet_transfer_code_faq_works_intro_2: As soon as the COVID certificate is available, it appears in the application. If you have activated notifications, you will receive a message from the application.
-    wallet_transfer_code_faq_works_intro_3: The transfer code expires after <transferCodeValidity> days. After this period, the application waits for any further transfers for 72 hours. After that, the transfer code is no longer valid.
+    wallet_transfer_code_faq_works_intro_3: The transfer code expires after {TRANSFER_CODE_VALIDITY} days. After this period, the application waits for any further transfers for 72 hours. After that, the transfer code is no longer valid.
     wallet_notification_permission_title: Allow notifications
     wallet_notification_permission_text: The app can notify you when your certificate is ready. Allow the app to send you notifications.
     wallet_notification_permission_button: Continue
@@ -444,3 +444,21 @@ en:
     verifier_qr_scanner_external_hardware_detected: External hardware scanner detected
     error_decryption_reset_button: Reset
     error_decryption_text: Certificates could not be loaded\n\nCode: {ERROR_CODE}
+    covid_certificate_sero_positiv_test_title: Recovery (Antibody)
+    wallet_time_inconsistency_error_title: Checking not possible
+    wallet_time_inconsistency_error_text: Date, time or time zone on the device are set incorrectly.
+    wallet_info_box_certificate_scan_title: Do you want to check certificates?
+    wallet_info_box_certificate_scan_text: For quicker checking that is data privacy compliant, use the COVID Certificate Check app
+    wallet_info_box_certificate_scan_button_check_app: To the Check-App
+    wallet_info_box_certificate_scan_close: Understood
+    wallet_info_box_certificate_scan_text_bold: «COVID Certificate Check»-App.
+    wallet_only_valid_in_switzerland: Only valid within Switzerland and in combination with an identity document
+    covid_certificate_sero_positiv_test_befund_label: Finding
+    covid_certificate_sero_positiv_test_befund_value: Sufficient
+    infobox_update_title: New version available
+    infobox_update_text: Download the latest version of the app.
+    infobox_update_button: Update
+    vaccination_impf_check_info_text: The COVID-19 Vaccination Check provides information on initial and booster vaccinations and guides you to the relevant point of contact in your canton.
+    vaccination_impf_check_action: To the Vaccination Check
+    vaccination_impf_check_url: https://covid19.impf-check.ch/
+    vaccination_impf_check_title: Book an appointment now

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
@@ -148,7 +148,7 @@ fr:
     covid_certificate_test_title: Test
     wallet_certificate_test_result_title: Résultat
     wallet_certificate_test_result_negativ: Non détecté (Négatif)
-    wallet_certificate_test_result_positiv: Positif
+    wallet_certificate_test_result_positiv: Détecté (Positif)
     wallet_certificate_test_type: Type
     wallet_certificate_test_name: Nom
     wallet_certificate_test_holder: Fabricant
@@ -242,7 +242,7 @@ fr:
     wallet_homescreen_network_error: La validité n’a pas pu être vérifiée
     wallet_transfer_code_faq_works_intro_1: L’application vérifie régulièrement si un certificat COVID est disponible pour votre code de transfert.
     wallet_transfer_code_faq_works_intro_2: Dès que le certificat COVID est disponible, il apparaît dans l’application. Si vous avez activé les notifications, vous recevrez un message de l’application.
-    wallet_transfer_code_faq_works_intro_3: Le code de transfert expire après <transferCodeValidity> jours. Une fois ce délai passé, l’application attend tout autre transfert pendant 72 h. Ensuite, le code de transfert n’est plus valable.
+    wallet_transfer_code_faq_works_intro_3: Le code de transfert expire après {TRANSFER_CODE_VALIDITY} jours. Une fois ce délai passé, l’application attend tout autre transfert pendant 72 h. Ensuite, le code de transfert n’est plus valable.
     wallet_notification_permission_title: Autoriser les messages
     wallet_notification_permission_text: L’application peut vous informer de l’émission du certificat. Pour cela, autorisez votre application à vous envoyer des messages.
     wallet_notification_permission_button: Suite
@@ -444,3 +444,21 @@ fr:
     verifier_qr_scanner_external_hardware_detected: Scanner matériel externe détecté
     error_decryption_reset_button: Réinitialiser
     error_decryption_text: Les certificats n'ont pas pu être chargés\n\nCode: {ERROR_CODE}
+    covid_certificate_sero_positiv_test_title: Guérison (Anticorps)
+    wallet_time_inconsistency_error_title: Contrôle impossible
+    wallet_time_inconsistency_error_text: La date, l’heure ou le fuseau horaire ne sont pas correctement paramétrés sur l’appareil.
+    wallet_info_box_certificate_scan_title: Voulez-vous contrôler des certificats?
+    wallet_info_box_certificate_scan_text: Pour un contrôle rapide respectant la protection des données, utilisez l’application «COVID Certificate Check».
+    wallet_info_box_certificate_scan_button_check_app: Vers Check-App
+    wallet_info_box_certificate_scan_close: Compris
+    wallet_info_box_certificate_scan_text_bold: «COVID Certificate Check»-App.
+    wallet_only_valid_in_switzerland: Valide uniquement en Suisse et avec un document d’identité
+    covid_certificate_sero_positiv_test_befund_label: Résultat
+    covid_certificate_sero_positiv_test_befund_value: Suffisant
+    infobox_update_title: Nouvelle version disponible
+    infobox_update_text: Téléchargez la nouvelle version de l'application.
+    infobox_update_button: Mettre à jour
+    vaccination_impf_check_info_text: COVID-19 Vac-check fournit des renseignements sur la première vaccination ainsi que sur la vaccination de rappel et vous guide vers le service compétent de votre canton.
+    vaccination_impf_check_action: Vers COVID-19 Vac-check
+    vaccination_impf_check_url: https://covid19-vac-check.ch/
+    vaccination_impf_check_title: Prendre un rendez-vous maintenant

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
@@ -148,7 +148,7 @@ it:
     covid_certificate_test_title: Test
     wallet_certificate_test_result_title: Risultato
     wallet_certificate_test_result_negativ: Non rilevato (Negativo)
-    wallet_certificate_test_result_positiv: Positivo
+    wallet_certificate_test_result_positiv: Rilevato (Positivo)
     wallet_certificate_test_type: Tipo
     wallet_certificate_test_name: Nome
     wallet_certificate_test_holder: Fabbricante
@@ -242,7 +242,7 @@ it:
     wallet_homescreen_network_error: Impossibile determinare la validità
     wallet_transfer_code_faq_works_intro_1: L’app verifica periodicamente se è disponibile un certificato COVID per il tuo codice di trasferimento.
     wallet_transfer_code_faq_works_intro_2: Non appena il certificato COVID è disponibile, viene visualizzato nell’app. Se hai attivato le notifiche, ne riceverai una dall’app.
-    wallet_transfer_code_faq_works_intro_3: Il codice di trasferimento scade dopo <transferCodeValidity> giorni. Poi l’app attende un eventuale trasferimento per altre 72 ore prima di considerare scaduto il codice.
+    wallet_transfer_code_faq_works_intro_3: Il codice di trasferimento scade dopo {TRANSFER_CODE_VALIDITY} giorni. Poi l’app attende un eventuale trasferimento per altre 72 ore prima di considerare scaduto il codice.
     wallet_notification_permission_title: Consenti notifiche
     wallet_notification_permission_text: L'app ti può informare non appena il certificato è pervenuto. Consenti all'app di inviarti le notifiche.
     wallet_notification_permission_button: Avanti
@@ -444,3 +444,21 @@ it:
     verifier_qr_scanner_external_hardware_detected: Rilevato uno scanner hardware esterno
     error_decryption_reset_button: Reset
     error_decryption_text: I certificati non possono essere caricati\n\nCode: {ERROR_CODE}
+    covid_certificate_sero_positiv_test_title: Guarigione (Anticorpi)
+    wallet_time_inconsistency_error_title: Impossibile effettuare la verifica
+    wallet_time_inconsistency_error_text: Impostazione di data, ora o fuso orario del dispositivo non corretta.
+    wallet_info_box_certificate_scan_title: Si vogliono verificare certificati?
+    wallet_info_box_certificate_scan_text: Per una verifica più rapida e conforme alla protezione dei dati, utilizzare l'app "COVID Certificate Check"
+    wallet_info_box_certificate_scan_button_check_app: All'app Check
+    wallet_info_box_certificate_scan_close: Capito
+    wallet_info_box_certificate_scan_text_bold: «COVID Certificate Check»-App.
+    wallet_only_valid_in_switzerland: Valido solo in Svizzera con un documento di legittimazione
+    covid_certificate_sero_positiv_test_befund_label: Risultati
+    covid_certificate_sero_positiv_test_befund_value: Sufficiente
+    infobox_update_title: È disponibile una nuova versione
+    infobox_update_text: Caricare la nuova versione dellʼapp.
+    infobox_update_button: Aggiorna
+    vaccination_impf_check_info_text: Il COVID-19 Vac-Check fornisce informazioni sulle prime vaccinazioni, sulle vaccinazioni di richiamo e ti indirizza verso il punto di contatto del tuo Cantone.
+    vaccination_impf_check_action: Vai al COVID-19 Vac-Check
+    vaccination_impf_check_url: https://covid19-vac-check.ch/
+    vaccination_impf_check_title: Prendi appuntamento ora

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
@@ -148,7 +148,7 @@ rm:
     covid_certificate_test_title: Test
     wallet_certificate_test_result_title: Resultat
     wallet_certificate_test_result_negativ: Betg identifitgà (Negativ)
-    wallet_certificate_test_result_positiv: Positiv
+    wallet_certificate_test_result_positiv: Identifitgà (Positiv)
     wallet_certificate_test_type: Tip
     wallet_certificate_test_name: Num
     wallet_certificate_test_holder: Producent
@@ -242,7 +242,7 @@ rm:
     wallet_homescreen_network_error: La valaivladad n’ha betg pudì vegnir eruida
     wallet_transfer_code_faq_works_intro_1: L'app verifitgescha regularmain, schebain in certificat COVID è disponibel per Voss code da transfer.
     wallet_transfer_code_faq_works_intro_2: Uschespert ch'il certificat COVID è disponibel, cumpara el en l'app. Sche Vus avais activà ils avis, vegnis Vus infurmada u infurmà da l'app.
-    wallet_transfer_code_faq_works_intro_3: Suenter <transferCodeValidity> dis scada il code da transfer. Silsuenter spetga l'app anc ulteriuras 72 uras, avant ch'il code da transfer daventa nunvalaivel.
+    wallet_transfer_code_faq_works_intro_3: Suenter {TRANSFER_CODE_VALIDITY} dis scada il code da transfer. Silsuenter spetga l'app anc ulteriuras 72 uras, avant ch'il code da transfer daventa nunvalaivel.
     wallet_notification_permission_title: Permetter avis
     wallet_notification_permission_text: L'app As po infurmar, uschespert ch'il certificat è arrivà. Permettai a l'app d'As trametter avis.
     wallet_notification_permission_button: Vinavant
@@ -444,3 +444,21 @@ rm:
     verifier_qr_scanner_external_hardware_detected: Identifitgà il scanner d'indriz tecnic extern
     error_decryption_reset_button: Reinizialisar
     error_decryption_text: Ils certificats n’han betg pudì vegnir chargiads\n\nCode: {ERROR_CODE}
+    covid_certificate_sero_positiv_test_title: Guariziun (Anticorpuls)
+    wallet_time_inconsistency_error_title: Verificaziun betg pussaivla
+    wallet_time_inconsistency_error_text: La data, las uras u la zona da temp sin l'apparat n'èn betg configuradas correctamain.
+    wallet_info_box_certificate_scan_title: Vulais Vus verifitgar certificats?
+    wallet_info_box_certificate_scan_text: Per ina verificaziun pli svelta e confurma a la protecziun da datas, utilisai l'app «COVID Certificate Check».
+    wallet_info_box_certificate_scan_button_check_app: Tar l'app «COVID Certificate Check»
+    wallet_info_box_certificate_scan_close: Chapì
+    wallet_info_box_certificate_scan_text_bold: «COVID Certificate Check»-App.
+    wallet_only_valid_in_switzerland: Valaivel mo cun in document da legitimaziun e mo en Svizra
+    covid_certificate_sero_positiv_test_befund_label: Diagnosa
+    covid_certificate_sero_positiv_test_befund_value: Suffizient
+    infobox_update_title: A disposiziun versiun nova
+    infobox_update_text: Chargiai giu la nova versiun da l'app.
+    infobox_update_button: Actualisar
+    vaccination_impf_check_info_text: Il check da vaccinaziun COVID-19 As infurmescha davart las emprimas vaccinaziuns sco er davart las vaccinaziuns da rinfrestgament ed As maina al post da consultaziun correspundent da Voss chantun.  
+    vaccination_impf_check_action: Al check da vaccinaziun
+    vaccination_impf_check_url: https://covid19.impf-check.ch/
+    vaccination_impf_check_title: Reservar in termin ussa

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
@@ -145,7 +145,7 @@ public class WalletConfigController {
         }
         for (var faqs: configResponse.getTransferWorks().values()) {
             faqs.getFaqIntroSections().forEach(
-                entry -> entry.setText(entry.getText().replaceAll("<transferCodeValidity>", transferCodeValidity)));
+                entry -> entry.setText(entry.getText().replace("{TRANSFER_CODE_VALIDITY}", transferCodeValidity)));
         }
 
         return ResponseEntity.ok()


### PR DESCRIPTION
The corresponding pattern in POEditor has been changed and the latest translations were pulled in