### PR TITLE
update three weeks popup texts

### DIFF
--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
@@ -523,8 +523,8 @@ de:
     wallet_eol_banner_invalid_in_three_weeks_detail_text: Dieses Zertifikat wird bald ablaufen.
     wallet_eol_banner_invalid_in_three_weeks_detail_more_info: Mehr erfahren
     wallet_eol_banner_invalid_in_three_weeks_popup_title: Info
-    wallet_eol_banner_invalid_in_three_weeks_popup_text1: Per 31. Jan. 2022 gelten in der Schweiz reduzierte Gültigkeitsdauern von 270 statt 365 Tagen für Covid-Zertifikate für Geimpfte oder Genesene. Dieses Zertifikat ist von der verkürzten Gültigkeitsdauer unmittelbar betroffen:
-    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Dieses Covid-Zertifikat ist ab dem 31. Jan. 2022 nur noch wenige Tage gültig.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text1: Seit dem 31. Jan. 2022 gelten in der Schweiz reduzierte Gültigkeitsdauern von 270 statt 365 Tagen für Covid-Zertifikate für Geimpfte oder Genesene. Dieses Zertifikat ist von der verkürzten Gültigkeitsdauer unmittelbar betroffen:
+    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Dieses Covid-Zertifikat ist nur noch wenige Tage gültig.
     wallet_eol_banner_invalid_in_three_weeks_popup_link_text: Mehr erfahren
     wallet_eol_banner_invalid_in_three_weeks_popup_link_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/warum-wird-die-gueltigkeitsdauer-der-zertifikate-fuer-eine-impfung-oder-eine
     wallet_eol_banner_invalid_from_first_february_homescreen_title: Verkürzte Gültigkeitsdauer
@@ -536,4 +536,4 @@ de:
     wallet_eol_banner_invalid_from_first_february_popup_bold_text: Dieses Covid-Zertifikat kann ab dem 31. Jan. 2022 nicht mehr verwendet werden, da die Gültigkeitsdauer dann bereits abgelaufen sein wird.
     wallet_eol_banner_invalid_from_first_february_popup_link_text: Mehr erfahren
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/warum-wird-die-gueltigkeitsdauer-der-zertifikate-fuer-eine-impfung-oder-eine
-    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Bitte beachten Sie das auf dem Zertifikat ausgewiesene Ablaufdatum, welches ab dem 31.1.2022 mit der reduzierten Gültigkeitsdauer von 270 Tagen berechnet wird.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Bitte beachten Sie das auf dem Zertifikat ausgewiesene neue Ablaufdatum, welches seit dem 31. Jan. 2022 mit einer reduzierten Gültigkeitsdauer von 270 Tagen berechnet wird.

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
@@ -524,7 +524,7 @@ en:
     wallet_eol_banner_invalid_in_three_weeks_detail_more_info: More information
     wallet_eol_banner_invalid_in_three_weeks_popup_title: Info
     wallet_eol_banner_invalid_in_three_weeks_popup_text1: As of 31 Jan 2022 a shortened period of validity of 270 instead of 365 days applies to COVID vaccination or recovery certificates in Switzerland. This certificate is directly affected by the shortened period of validity:
-    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: This COVID certificate will only be valid for a few days after 31 Jan 2022.
+    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: This COVID certificate is valid for only a few more days.
     wallet_eol_banner_invalid_in_three_weeks_popup_link_text: More information
     wallet_eol_banner_invalid_in_three_weeks_popup_link_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-period-validity-certificates-vaccination-or-recovery-being-shortened-365-270
     wallet_eol_banner_invalid_from_first_february_homescreen_title: Shortened period of validity
@@ -536,4 +536,4 @@ en:
     wallet_eol_banner_invalid_from_first_february_popup_bold_text: This COVID certificate can no longer be used after 31 Jan 2022 as the period of validity will already have expired.
     wallet_eol_banner_invalid_from_first_february_popup_link_text: More information
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-period-validity-certificates-vaccination-or-recovery-being-shortened-365-270
-    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Please note the expiry date shown on your certificate, which from 31 Jan 2022 is calculated based on the shortened period of validity of 270 days.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Please note the new expiry date shown on the certificate, which since 31 January 2022 has been calculated on the basis of the reduced period of validity of 270 days.

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
@@ -523,8 +523,8 @@ fr:
     wallet_eol_banner_invalid_in_three_weeks_detail_text: Ce certificat expirera bientôt.
     wallet_eol_banner_invalid_in_three_weeks_detail_more_info: En savoir plus
     wallet_eol_banner_invalid_in_three_weeks_popup_title: Info
-    wallet_eol_banner_invalid_in_three_weeks_popup_text1: À partir du 31 janvier 2022, la durée de validité en Suisse des certificats COVID pour les personnes vaccinées ou guéries est réduite de 365 à 270 jours. Ce certificat est directement concerné:
-    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Ce certificat COVID est valable encore seulement quelques jours à partir du 31 janvier 2022.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text1: Depuis le 31 janvier 2022, la durée de validité des certificats COVID pour personnes vaccinées ou guéries a été raccourcie de 365 à 270 jours en Suisse. La nouvelle durée de validité réduite a été directement appliquée à ce certificat:
+    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Ce certificat COVID est encore valable quelques jours.
     wallet_eol_banner_invalid_in_three_weeks_popup_link_text: En savoir plus
     wallet_eol_banner_invalid_in_three_weeks_popup_link_url: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/pourquoi-la-duree-de-validite-des-certificats-de-vaccination-ou-de-guerison-t-elle
     wallet_eol_banner_invalid_from_first_february_homescreen_title: Durée de validité réduite
@@ -536,4 +536,4 @@ fr:
     wallet_eol_banner_invalid_from_first_february_popup_bold_text: Ce certificat COVID ne peut plus être utilisé à partir du 31 janvier 2022.
     wallet_eol_banner_invalid_from_first_february_popup_link_text: En savoir plus
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/pourquoi-la-duree-de-validite-des-certificats-de-vaccination-ou-de-guerison-t-elle
-    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Veuillez noter la date d’expiration indiquée sur le certificat, calculée à partir du 31 janvier 2022 avec la durée de validité réduite de 270 jours.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Nous attirons votre attention sur la nouvelle date de fin de validité affichée qui correspond à la durée réduite de 270 jours en vigueur depuis le 31 janvier 2022.

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
@@ -523,8 +523,8 @@ it:
     wallet_eol_banner_invalid_in_three_weeks_detail_text: Questo certificato sta per scadere.
     wallet_eol_banner_invalid_in_three_weeks_detail_more_info: Per saperne di più
     wallet_eol_banner_invalid_in_three_weeks_popup_title: Info
-    wallet_eol_banner_invalid_in_three_weeks_popup_text1: Dal 31 gennaio 2022 in Svizzera vige una durata di validità del certificato COVID per persone vaccinate o guarite di 270 anziché di 365 giorni. Questo certificato è interessato direttamente dall’abbreviazione della durata di validità:
-    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Questo certificato COVID scade pochi giorni dopo il 31 gennaio 2022.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text1: Dal 31 gennaio 2022 in Svizzera si applica una durata di validità abbreviata da 365 a 270 giorni per i certificati COVID per persone vaccinate o guarite. Questo certificato è direttamente interessato dalla durata di validità abbreviata:
+    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Questo certificato COVID è ancora valido soltanto per pochi giorni.
     wallet_eol_banner_invalid_in_three_weeks_popup_link_text: Per saperne di più
     wallet_eol_banner_invalid_in_three_weeks_popup_link_url: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/perche-la-durata-di-validita-dei-certificati-di-vaccinazione-o-di-guarigione-e
     wallet_eol_banner_invalid_from_first_february_homescreen_title: Durata di validità abbreviata
@@ -536,4 +536,4 @@ it:
     wallet_eol_banner_invalid_from_first_february_popup_bold_text: La scadenza della durata di validità di questo certificato COVID è il 31 gennaio 2022. Pertanto il certificato non è più utilizzabile dopo quella data.
     wallet_eol_banner_invalid_from_first_february_popup_link_text: Per saperne di più
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/perche-la-durata-di-validita-dei-certificati-di-vaccinazione-o-di-guarigione-e
-    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Verifichi la data di scadenza indicata sul certificato, che dal 31 gennaio 2022 è calcolata su una durata di validità ridotta a 270 giorni.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Si prega di notare la nuova data di scadenza indicata sul certificato, che dal 31 gennaio 2022 è calcolata sulla base della durata di validità abbreviata di 270 giorni.

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
@@ -523,8 +523,8 @@ rm:
     wallet_eol_banner_invalid_in_three_weeks_detail_text: Quest certificat scada bainbaud.
     wallet_eol_banner_invalid_in_three_weeks_detail_more_info: Dapli infurmaziuns
     wallet_eol_banner_invalid_in_three_weeks_popup_title: Info
-    wallet_eol_banner_invalid_in_three_weeks_popup_text1: A partir dals 31-01-2022 valan en Svizra duradas da valaivladad reducidas da 270 dis empè da 365 dis per certificats COVID per persunas vaccinadas u guaridas. Quest certificat è pertutgà directamain da la valaivladad pli curta:
-    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Quest certificat COVID è valaivel mo pli per intgins dis a partir dals 31-01-2022.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text1: Dapi ils 31 da schaner 2022 valan en Svizra duradas da valaivladad reducidas da 270 empè da 365 dis per ils certificats COVID da persunas vaccinadas u guaridas. Quest certificat è pertutgà directamain da la durada da valaivladad reducida:
+    wallet_eol_banner_invalid_in_three_weeks_popup_bold_text: Quest certificat COVID vala mo pli durant paucs dis.
     wallet_eol_banner_invalid_in_three_weeks_popup_link_text: Dapli infurmaziuns
     wallet_eol_banner_invalid_in_three_weeks_popup_link_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/warum-wird-die-gueltigkeitsdauer-der-zertifikate-fuer-eine-impfung-oder-eine
     wallet_eol_banner_invalid_from_first_february_homescreen_title: Valaivladad pli curta
@@ -536,4 +536,4 @@ rm:
     wallet_eol_banner_invalid_from_first_february_popup_bold_text: Quest certificat COVID na po betg pli vegnir duvrà a partir dals 31-01-2022, perquai che la durada da valaivladad è lura gia scadida.
     wallet_eol_banner_invalid_from_first_february_popup_link_text: Dapli infurmaziuns
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/warum-wird-die-gueltigkeitsdauer-der-zertifikate-fuer-eine-impfung-oder-eine
-    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Resguardai per plaschair la data da scadenza inditgada sin il certificat. A partir dals 31-01-2022 vegn questa data calculada sin basa da la valaivladad pli curta da 270 dis.
+    wallet_eol_banner_invalid_in_three_weeks_popup_text2: Resguardai per plaschair la nova data da scadenza sin il certificat. Dapi ils 31 da schaner 2022 vegn questa data calculada sin basa da la durada da valaivladad reducida da 270 dis.


### PR DESCRIPTION
This pull request updates some info texts for certificates that expire within three weeks of January 31st due to the change in validity duration of vaccination and recovery certificates.