### PR TITLE
add generic infobox and show it to all wallet apps

### DIFF
--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/java/ch/admin/bag/covidcertificate/backend/config/shared/helper/InfoBoxHelper.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/java/ch/admin/bag/covidcertificate/backend/config/shared/helper/InfoBoxHelper.java
@@ -33,4 +33,24 @@ public class InfoBoxHelper {
         }
         return result;
     }
+
+    public Map<Language, InfoBox> getGenericInfoBox(boolean forAndroid) {
+        Map<Language, InfoBox> result = new EnumMap<>(Language.class);
+        for (Language language : Language.values()) {
+            Locale l = language.toLocale();
+            InfoBox infoBox = new InfoBox();
+            infoBox.setTitle(msg.getMessage("infobox_generic_title", l));
+            infoBox.setMsg(msg.getMessage("infobox_generic_text", l));
+            if (forAndroid) {
+                infoBox.setUrl(msg.getMessage("infobox_generic_url_android", l));
+            } else { // iOS
+                infoBox.setUrl(msg.getMessage("infobox_generic_url_ios", l));
+            }
+            infoBox.setUrlTitle(msg.getMessage("infobox_generic_button", l));
+            infoBox.setIsDismissible(false);
+            result.put(language, infoBox);
+        }
+        return result;
+    }
+
 }

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/java/ch/admin/bag/covidcertificate/backend/config/shared/helper/InfoBoxHelper.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/java/ch/admin/bag/covidcertificate/backend/config/shared/helper/InfoBoxHelper.java
@@ -47,7 +47,7 @@ public class InfoBoxHelper {
                 infoBox.setUrl(msg.getMessage("infobox_generic_url_ios", l));
             }
             infoBox.setUrlTitle(msg.getMessage("infobox_generic_button", l));
-            infoBox.setIsDismissible(false);
+            infoBox.setIsDismissible(true);
             result.put(language, infoBox);
         }
         return result;

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
@@ -343,7 +343,7 @@ de:
     wallet_faq_works_question_2_1: Was ist ein Transfer-Code?
     wallet_faq_works_answer_2_1: Mit Transfer-Codes können Covid-Zertifikate schnell und sicher übermittelt werden. Auf diesem Weg erhalten Sie das Covid-Zertifikat, z. B. nach einem Covid-Test, direkt in die App geliefert.
     wallet_faq_works_question_5_1: Ich habe das Covid-Zertifikat ausschliesslich elektronisch in der App. Wie komme ich zum Zertifikat als PDF oder auf Papier?
-    wallet_faq_works_answer_5_1: In der «COVID Certificate»-App finden Sie in der Detailansicht des elektronische Covid-Zertifikats die Funktion «Exportieren». Damit können Sie ein PDF erstellen, dieses speichern und ausdrucken.
+    wallet_faq_works_answer_5_1: In der «COVID Certificate»-App finden Sie in der Detailansicht des elektronischen Covid-Zertifikats die Funktion «Exportieren». Damit können Sie ein PDF erstellen, dieses speichern und ausdrucken.
     wallet_android_app_google_play_store_url: market://details?id=ch.admin.bag.covidcertificate.wallet
     verifier_android_app_google_play_store_url: market://details?id=ch.admin.bag.covidcertificate.verifier
     wallet_certificate_light_rate_limit_title: 24h-Limite erreicht
@@ -537,3 +537,8 @@ de:
     wallet_eol_banner_invalid_from_first_february_popup_link_text: Mehr erfahren
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/warum-wird-die-gueltigkeitsdauer-der-zertifikate-fuer-eine-impfung-oder-eine
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Bitte beachten Sie das auf dem Zertifikat ausgewiesene neue Ablaufdatum, welches seit dem 31. Jan. 2022 mit einer reduzierten Gültigkeitsdauer von 270 Tagen berechnet wird.
+    infobox_generic_title: Zertifikat sichern!
+    infobox_generic_text: Wenn Sie die App löschen, Ihr Smartphone wechseln oder verlieren, gehen auch Ihre Covid-Zertifikate verloren.\nBewahren Sie Ihre Zertifikate daher auch ausserhalb der App auf, indem Sie diese als PDF exportieren.
+    infobox_generic_button: Zertifikat sichern!
+    infobox_generic_url_android: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate
+    infobox_generic_url_ios: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_de.properties
@@ -539,6 +539,6 @@ de:
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Bitte beachten Sie das auf dem Zertifikat ausgewiesene neue Ablaufdatum, welches seit dem 31. Jan. 2022 mit einer reduzierten Gültigkeitsdauer von 270 Tagen berechnet wird.
     infobox_generic_title: Zertifikat sichern!
     infobox_generic_text: Wenn Sie die App löschen, Ihr Smartphone wechseln oder verlieren, gehen auch Ihre Covid-Zertifikate verloren.\nBewahren Sie Ihre Zertifikate daher auch ausserhalb der App auf, indem Sie diese als PDF exportieren.
-    infobox_generic_button: Zertifikat sichern!
+    infobox_generic_button: Mehr erfahren
     infobox_generic_url_android: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate
     infobox_generic_url_ios: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
@@ -539,6 +539,6 @@ en:
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Please note the new expiry date shown on the certificate, which since 31 January 2022 has been calculated on the basis of the reduced period of validity of 270 days.
     infobox_generic_title: Back up your certificate!
     infobox_generic_text: If you uninstall the app or change or lose your smartphone, you will also lose your COVID certificates.\nThis means you should also keep a copy of your certificates outside the app by exporting them as PDFs.
-    infobox_generic_button: Back up your certificate!
+    infobox_generic_button: Find out more
     infobox_generic_url_android: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i
     infobox_generic_url_ios: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_en.properties
@@ -537,3 +537,8 @@ en:
     wallet_eol_banner_invalid_from_first_february_popup_link_text: More information
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-period-validity-certificates-vaccination-or-recovery-being-shortened-365-270
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Please note the new expiry date shown on the certificate, which since 31 January 2022 has been calculated on the basis of the reduced period of validity of 270 days.
+    infobox_generic_title: Back up your certificate!
+    infobox_generic_text: If you uninstall the app or change or lose your smartphone, you will also lose your COVID certificates.\nThis means you should also keep a copy of your certificates outside the app by exporting them as PDFs.
+    infobox_generic_button: Back up your certificate!
+    infobox_generic_url_android: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i
+    infobox_generic_url_ios: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
@@ -537,3 +537,8 @@ fr:
     wallet_eol_banner_invalid_from_first_february_popup_link_text: En savoir plus
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/pourquoi-la-duree-de-validite-des-certificats-de-vaccination-ou-de-guerison-t-elle
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Nous attirons votre attention sur la nouvelle date de fin de validité affichée qui correspond à la durée réduite de 270 jours en vigueur depuis le 31 janvier 2022.
+    infobox_generic_title: Sauvegardez vos certificats!
+    infobox_generic_text: Si vous supprimez l’application, changez de smartphone ou le perdez, vos certificats COVID seront également perdus.\nConservez donc vos certificats en dehors de l’application en les exportant au format PDF.
+    infobox_generic_button: Sauvegardez vos certificats!
+    infobox_generic_url_android: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/mon-certificat-covid-nest-disponible-quau-format-electronique-dans-lapplication
+    infobox_generic_url_ios: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/mon-certificat-covid-nest-disponible-quau-format-electronique-dans-lapplication

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_fr.properties
@@ -539,6 +539,6 @@ fr:
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Nous attirons votre attention sur la nouvelle date de fin de validité affichée qui correspond à la durée réduite de 270 jours en vigueur depuis le 31 janvier 2022.
     infobox_generic_title: Sauvegardez vos certificats!
     infobox_generic_text: Si vous supprimez l’application, changez de smartphone ou le perdez, vos certificats COVID seront également perdus.\nConservez donc vos certificats en dehors de l’application en les exportant au format PDF.
-    infobox_generic_button: Sauvegardez vos certificats!
+    infobox_generic_button: Plus d’informations
     infobox_generic_url_android: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/mon-certificat-covid-nest-disponible-quau-format-electronique-dans-lapplication
     infobox_generic_url_ios: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/mon-certificat-covid-nest-disponible-quau-format-electronique-dans-lapplication

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
@@ -539,6 +539,6 @@ it:
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Si prega di notare la nuova data di scadenza indicata sul certificato, che dal 31 gennaio 2022 è calcolata sulla base della durata di validità abbreviata di 270 giorni.
     infobox_generic_title: Mettete al sicuro il vostro certificato!
     infobox_generic_text: Se cancellate l’app, cambiate o smarrite il vostro smartphone, anche i vostri certificati COVID andranno persi. \nConservate quindi i vostri certificati anche al di fuori dell’app esportandoli in formato PDF.
-    infobox_generic_button: Mettete al sicuro il vostro certificato!
+    infobox_generic_button: Per maggiori informazioni
     infobox_generic_url_android: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/ho-il-certificato-covid-esclusivamente-formato-elettronico-nellapp-covid
     infobox_generic_url_ios: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/ho-il-certificato-covid-esclusivamente-formato-elettronico-nellapp-covid

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_it.properties
@@ -537,3 +537,8 @@ it:
     wallet_eol_banner_invalid_from_first_february_popup_link_text: Per saperne di più
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/perche-la-durata-di-validita-dei-certificati-di-vaccinazione-o-di-guarigione-e
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Si prega di notare la nuova data di scadenza indicata sul certificato, che dal 31 gennaio 2022 è calcolata sulla base della durata di validità abbreviata di 270 giorni.
+    infobox_generic_title: Mettete al sicuro il vostro certificato!
+    infobox_generic_text: Se cancellate l’app, cambiate o smarrite il vostro smartphone, anche i vostri certificati COVID andranno persi. \nConservate quindi i vostri certificati anche al di fuori dell’app esportandoli in formato PDF.
+    infobox_generic_button: Mettete al sicuro il vostro certificato!
+    infobox_generic_url_android: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/ho-il-certificato-covid-esclusivamente-formato-elettronico-nellapp-covid
+    infobox_generic_url_ios: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/ho-il-certificato-covid-esclusivamente-formato-elettronico-nellapp-covid

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
@@ -539,6 +539,6 @@ rm:
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Resguardai per plaschair la nova data da scadenza sin il certificat. Dapi ils 31 da schaner 2022 vegn questa data calculada sin basa da la durada da valaivladad reducida da 270 dis.
     infobox_generic_title: Tegnair en salv il certificat!
     infobox_generic_text: Sche Vus stizzais l'app, midais u perdais Voss smartphone, van er a perder Voss certificats COVID. \nTegnai perquai en salv Voss certificats er ordaifer l'app cun exportar quels sco PDF.
-    infobox_generic_button: Tegnair en salv il certificat!
+    infobox_generic_button: Dapli infurmaziuns
     infobox_generic_url_android: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate
     infobox_generic_url_ios: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-shared/src/main/resources/i18n/messages_rm.properties
@@ -537,3 +537,8 @@ rm:
     wallet_eol_banner_invalid_from_first_february_popup_link_text: Dapli infurmaziuns
     wallet_eol_banner_invalid_from_first_february_popup_link_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/warum-wird-die-gueltigkeitsdauer-der-zertifikate-fuer-eine-impfung-oder-eine
     wallet_eol_banner_invalid_in_three_weeks_popup_text2: Resguardai per plaschair la nova data da scadenza sin il certificat. Dapi ils 31 da schaner 2022 vegn questa data calculada sin basa da la durada da valaivladad reducida da 270 dis.
+    infobox_generic_title: Tegnair en salv il certificat!
+    infobox_generic_text: Sche Vus stizzais l'app, midais u perdais Voss smartphone, van er a perder Voss certificats COVID. \nTegnai perquai en salv Voss certificats er ordaifer l'app cun exportar quels sco PDF.
+    infobox_generic_button: Tegnair en salv il certificat!
+    infobox_generic_url_android: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate
+    infobox_generic_url_ios: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/main/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/controller/WalletConfigController.java
@@ -156,9 +156,12 @@ public class WalletConfigController {
             configResponse.setForceUpdate(true);
         }
 
-        if (clientAppVersion.isSmallerVersionThan(INFOBOX_BELOW_2_7_0)) {
+        /*if (clientAppVersion.isSmallerVersionThan(INFOBOX_BELOW_2_7_0)) {
             configResponse.setInfoBox(infoBoxHelper.getUpdateInfoBox(clientAppVersion.isAndroid()));
-        }
+        }*/
+
+        configResponse.setInfoBox(infoBoxHelper.getGenericInfoBox(clientAppVersion.isAndroid()));
+
 
         replacePoeditorPlaceHolders(configResponse, clientAppVersion);
 

--- a/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/test/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/BaseControllerTest.java
+++ b/ch-covidcertificate-backend-config/ch-covidcertificate-backend-config-wallet-ws/src/test/java/ch/admin/bag/covidcertificate/backend/config/wallet/ws/BaseControllerTest.java
@@ -124,8 +124,10 @@ public abstract class BaseControllerTest {
 
     @Test
     public void testForUpdateNote() throws Exception {
+        MockHttpServletResponse result;
+        ConfigResponse resp;
         // no update info box
-        MockHttpServletResponse result =
+        /*result =
                 mockMvc.perform(
                                 get(BASE_URL + "/config")
                                         .accept(acceptMediaType)
@@ -135,17 +137,17 @@ public abstract class BaseControllerTest {
                         .andExpect(status().is2xxSuccessful())
                         .andReturn()
                         .getResponse();
-        ConfigResponse resp =
+        resp =
                 testHelper.toConfigResponse(result, acceptMediaType, TestHelper.PATH_TO_CA_PEM);
-        ConfigAsserter.assertNoUpdate(resp);
+        ConfigAsserter.assertNoUpdate(resp);*/
 
-        // update info box (<2.7.0)
+        // info box for everyone
         result =
                 mockMvc.perform(
                                 get(BASE_URL + "/config")
                                         .accept(acceptMediaType)
                                         .param("osversion", "android9")
-                                        .param("appversion", "android-2.6.0")
+                                        .param("appversion", "android-3.5.0")
                                         .param("buildnr", "1622464850983"))
                         .andExpect(status().is2xxSuccessful())
                         .andReturn()


### PR DESCRIPTION
Adds a new type of infobox with its corresponding translations and shows it on all versions of the wallet app (overriding the update infobox)